### PR TITLE
Add support for incremental build info descriptors via Gradle

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoFields.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoFields.java
@@ -44,4 +44,5 @@ public interface BuildInfoFields {
     String RELEASE_COMMENT = "promotion.comment";
     String BUILD_ROOT = "build.root";
     String RUN_PARAMETERS = "runParameters.";
+    String INCREMENTAL = "incremental";
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/dsl/ArtifactoryPluginConvention.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/dsl/ArtifactoryPluginConvention.groovy
@@ -65,5 +65,9 @@ class ArtifactoryPluginConvention {
     def proxy(Closure closure) {
         ConfigureUtil.configure(closure, new DoubleDelegateWrapper(clientConfig.proxy))
     }
+
+    def parent(Closure closure) {
+        new ParentConfig(this).config(closure)
+    }
 }
 

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/dsl/ParentConfig.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/dsl/ParentConfig.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2011 JFrog Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jfrog.gradle.plugin.artifactory.dsl
+
+import org.gradle.util.ConfigureUtil
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration
+
+/**
+ * @author Noam Y. Tenne
+ */
+class ParentConfig {
+
+    private final ArtifactoryClientConfiguration.BuildInfoHandler info
+
+    ParentConfig(ArtifactoryPluginConvention conv) {
+        info = conv.clientConfig.info
+        info.incremental = Boolean.TRUE
+    }
+
+    def config(Closure closure) {
+        ConfigureUtil.configure(closure, this)
+    }
+
+    def propertyMissing(String name, value) {
+        info."$name" = value
+    }
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -1062,5 +1062,13 @@ public class ArtifactoryClientConfiguration {
 
             return runParameters;
         }
+
+        public Boolean isIncremental() {
+            return getBooleanValue(INCREMENTAL, Boolean.FALSE);
+        }
+
+        public void setIncremental(Boolean incremental) {
+            setBooleanValue(INCREMENTAL, incremental);
+        }
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
@@ -23,6 +23,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -51,6 +52,8 @@ import java.io.*;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.util.*;
+
+import static org.jfrog.build.client.ArtifactoryHttpClient.encodeUrl;
 
 /**
  * Artifactory client to perform build info related tasks.
@@ -232,18 +235,7 @@ public class ArtifactoryBuildInfoClient {
     public void sendBuildInfo(String buildInfoJson) throws IOException {
         String url = artifactoryUrl + BUILD_REST_URL;
         HttpPut httpPut = new HttpPut(url);
-        StringEntity stringEntity = new StringEntity(buildInfoJson, "UTF-8");
-        stringEntity.setContentType("application/vnd.org.jfrog.artifactory+json");
-        httpPut.setEntity(stringEntity);
-        log.info("Deploying build info to: " + url);
-        HttpResponse response = httpClient.getHttpClient().execute(httpPut);
-        if (response.getEntity() != null) {
-            EntityUtils.consume(response.getEntity());
-        }
-        StatusLine statusLine = response.getStatusLine();
-        if (statusLine.getStatusCode() != HttpStatus.SC_NO_CONTENT) {
-            throwHttpIOException("Failed to send build info:", statusLine);
-        }
+        sendDescriptor(httpPut, buildInfoJson);
     }
 
     /**
@@ -260,7 +252,34 @@ public class ArtifactoryBuildInfoClient {
             log.error("Could not build the build-info object.", e);
             throw new IOException("Could not publish build-info: " + e.getMessage());
         }
+    }
 
+    public void sendModuleInfo(Build build) throws IOException {
+        try {
+            String url = artifactoryUrl + BUILD_REST_URL + "/append/" + encodeUrl(build.getName()) + "/" +
+                    encodeUrl(build.getNumber());
+            HttpPost httpPost = new HttpPost(url);
+            String modulesAsJsonString = toJsonString(build.getModules());
+            sendDescriptor(httpPost, modulesAsJsonString);
+        } catch (Exception e) {
+            log.error("Could not build the build-info modules object.", e);
+            throw new IOException("Could not publish build-info modules: " + e.getMessage());
+        }
+    }
+
+    private void sendDescriptor(HttpEntityEnclosingRequestBase request, String content) throws IOException {
+        StringEntity stringEntity = new StringEntity(content, "UTF-8");
+        stringEntity.setContentType("application/vnd.org.jfrog.artifactory+json");
+        request.setEntity(stringEntity);
+        log.info("Deploying build descriptor to: " + request.getURI().toString());
+        HttpResponse response = httpClient.getHttpClient().execute(request);
+        if (response.getEntity() != null) {
+            EntityUtils.consume(response.getEntity());
+        }
+        StatusLine statusLine = response.getStatusLine();
+        if (statusLine.getStatusCode() != HttpStatus.SC_NO_CONTENT) {
+            throwHttpIOException("Failed to send build descriptor :", statusLine);
+        }
     }
 
     public String getItemLastModified(String path) throws IOException, ParseException {
@@ -311,7 +330,7 @@ public class ArtifactoryBuildInfoClient {
         deploymentPathBuilder.append(details.getArtifactPath());
         String deploymentPath = deploymentPathBuilder.toString();
         log.info("Deploying artifact: " + deploymentPath);
-        deploymentPath = ArtifactoryHttpClient.encodeUrl(deploymentPath);
+        deploymentPath = encodeUrl(deploymentPath);
         ArtifactoryUploadResponse response = uploadFile(details, deploymentPath);
         // Artifactory 2.3.2+ will take the checksum from the headers of the put request for the file
         if (!getArtifactoryVersion().isAtLeast(new ArtifactoryVersion("2.3.2"))) {
@@ -379,7 +398,7 @@ public class ArtifactoryBuildInfoClient {
     }
 
     // create pushToBintray request Url
-    private String createRequestUrl(String buildName, String buildNumber, String signMethod, String passphrase){
+    private String createRequestUrl(String buildName, String buildNumber, String signMethod, String passphrase) {
         StringBuilder urlBuilder = new StringBuilder(artifactoryUrl).append(PUSH_TO_BINTRAY_REST_URL).append(buildName)
                 .append("/").append(buildNumber);
 
@@ -419,8 +438,7 @@ public class ArtifactoryBuildInfoClient {
         }
 
         StringBuilder urlBuilder = new StringBuilder(artifactoryUrl).append(BUILD_REST_URL).append("/promote/").
-                append(ArtifactoryHttpClient.encodeUrl(buildName)).append("/").append(ArtifactoryHttpClient.
-                encodeUrl(buildNumber));
+                append(encodeUrl(buildName)).append("/").append(encodeUrl(buildNumber));
 
         String promotionJson = toJsonString(promotion);
 
@@ -473,8 +491,8 @@ public class ArtifactoryBuildInfoClient {
     public Map getStagingStrategy(String strategyName, String buildName, Map<String, String> requestParams)
             throws IOException {
         StringBuilder urlBuilder = new StringBuilder(artifactoryUrl).append("/api/plugins/build/staging/")
-                .append(ArtifactoryHttpClient.encodeUrl(strategyName)).append("?buildName=")
-                .append(ArtifactoryHttpClient.encodeUrl(buildName)).append("&");
+                .append(encodeUrl(strategyName)).append("?buildName=")
+                .append(encodeUrl(buildName)).append("&");
         appendParamsToUrl(requestParams, urlBuilder);
         HttpGet getRequest = new HttpGet(urlBuilder.toString());
         HttpResponse response = httpClient.getHttpClient().execute(getRequest);
@@ -505,8 +523,8 @@ public class ArtifactoryBuildInfoClient {
     public HttpResponse executePromotionUserPlugin(String promotionName, String buildName, String buildNumber,
                                                    Map<String, String> requestParams) throws IOException {
         StringBuilder urlBuilder = new StringBuilder(artifactoryUrl).append("/api/plugins/build/promote/")
-                .append(promotionName).append("/").append(ArtifactoryHttpClient.encodeUrl(buildName)).append("/")
-                .append(ArtifactoryHttpClient.encodeUrl(buildNumber)).append("?");
+                .append(promotionName).append("/").append(encodeUrl(buildName)).append("/")
+                .append(encodeUrl(buildNumber)).append("?");
         appendParamsToUrl(requestParams, urlBuilder);
         HttpPost postRequest = new HttpPost(urlBuilder.toString());
         return httpClient.getHttpClient().execute(postRequest);
@@ -526,13 +544,13 @@ public class ArtifactoryBuildInfoClient {
         if ((requestParams != null) && !requestParams.isEmpty()) {
             urlBuilder.append("params=");
             Iterator<Map.Entry<String, String>> paramEntryIterator = requestParams.entrySet().iterator();
-            String encodedPipe = ArtifactoryHttpClient.encodeUrl("|");
+            String encodedPipe = encodeUrl("|");
             while (paramEntryIterator.hasNext()) {
                 Map.Entry<String, String> paramEntry = paramEntryIterator.next();
-                urlBuilder.append(ArtifactoryHttpClient.encodeUrl(paramEntry.getKey()));
+                urlBuilder.append(encodeUrl(paramEntry.getKey()));
                 String paramValue = paramEntry.getValue();
                 if (StringUtils.isNotBlank(paramValue)) {
-                    urlBuilder.append("=").append(ArtifactoryHttpClient.encodeUrl(paramValue));
+                    urlBuilder.append("=").append(encodeUrl(paramValue));
                 }
 
                 if (paramEntryIterator.hasNext()) {


### PR DESCRIPTION
This modification introduces the 'parent' closure to the Gradle plugin; when configured, all generated build info modules will be appended to the pre-existing descriptor of the build specified in the 'parent' closure.