### PR TITLE
explicitly make artifactoryPublish task depend according pom generati…

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoPublicationsTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoPublicationsTask.java
@@ -146,6 +146,8 @@ public class BuildInfoPublicationsTask extends BuildInfoBaseTask {
                 continue;
             }
             dependsOn(((MavenPublicationInternal) mavenPublication).getPublishableFiles());
+            String capitalizedPublicationName = mavenPublication.getName().substring(0, 1).toUpperCase() + mavenPublication.getName().substring(1);
+            dependsOn(String.format("generatePomFileFor%sPublication", capitalizedPublicationName));
         }
     }
 


### PR DESCRIPTION
this is a fix for issue #49 I just raised to make the gradle artifactory plugin usuable with gradle 2.4