### PR TITLE
Fix HTTP response 500 on artifactoryPublish.

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
@@ -374,7 +374,6 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
                 } else {
                     log.debug("Publishing build info to artifactory at: '{}'", contextUrl);
                     client.sendBuildInfo(build);
-                    client.sendBuildInfo(build);
                 }
             }
         } finally {


### PR DESCRIPTION
When doing `./gradlew artifactoryPublish` in our project with the latest version (i.e. `master`), we get

```
Caused by: java.io.IOException: Could not publish build-info: Failed to send build descriptor : HTTP response code: 500. HTTP response message: Internal Server Error
	at org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient.sendBuildInfo(ArtifactoryBuildInfoClient.java:244)
	at org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask.prepareAndDeploy(BuildInfoBaseTask.java:377)
	at org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask.collectProjectBuildInfo(BuildInfoBaseTask.java:126)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:75)
	... 64 more
```

This doesn't happen with the latest released version (i.e. `build-info-extractor-gradle-3.1.2`). 
This is due to a duplicated line in the code. 

@maikelvdh, @ffung, you might be interested.