### PR TITLE
Deterministic publish order for gradle and ivy

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/DeployDetails.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/DeployDetails.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.api.BuildFileBean;
 
 import java.io.File;
+import java.lang.Comparable;
 import java.util.Map;
 import java.util.Properties;
 
@@ -29,7 +30,7 @@ import java.util.Properties;
  *
  * @author Yossi Shaul
  */
-public class DeployDetails {
+public class DeployDetails implements Comparable<DeployDetails> {
     /**
      * Artifact deployment path.
      */
@@ -80,6 +81,10 @@ public class DeployDetails {
 
     public String getMd5() {
         return md5;
+    }
+    
+    public int compareTo(DeployDetails that) {
+        return this.artifactPath.compareTo(that.artifactPath);
     }
 
     @Override

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
@@ -25,7 +25,7 @@ import org.jfrog.build.client.DeployDetails;
  *
  * @author Tomer Cohen
  */
-public class GradleDeployDetails {
+public class GradleDeployDetails implements Comparable<GradleDeployDetails> {
 
     private final DeployDetails deployDetails;
     private final PublishArtifactInfo publishArtifact;
@@ -47,6 +47,30 @@ public class GradleDeployDetails {
 
     public PublishArtifactInfo getPublishArtifact() {
         return publishArtifact;
+    }
+    
+    public int compareTo(GradleDeployDetails that) {
+        int result = 0;
+        if (this.deployDetails == null) {
+            result = that.deployDetails == null ? 0 : -1;
+        } else {
+            result = this.deployDetails.compareTo(that.deployDetails);
+        }
+        if (result == 0) {
+            if (this.publishArtifact == null) {
+                result = that.publishArtifact == null ? 0 : -1;
+            } else {
+                result = this.publishArtifact.compareTo(that.publishArtifact);
+            }
+        }
+        if (result == 0) {
+            if (this.project == null) {
+                result = that.project == null ? 0 : -1;
+            } else {
+                result = this.project.compareTo(that.project);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/PublishArtifactInfo.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/PublishArtifactInfo.java
@@ -19,6 +19,7 @@ package org.jfrog.gradle.plugin.artifactory.extractor;
 import org.gradle.api.artifacts.PublishArtifact;
 
 import java.io.File;
+import java.lang.Comparable;
 import java.util.Map;
 import javax.xml.namespace.QName;
 
@@ -27,7 +28,7 @@ import javax.xml.namespace.QName;
  *
  * @author Yoav Landman
  */
-public class PublishArtifactInfo {
+public class PublishArtifactInfo implements Comparable<PublishArtifactInfo> {
 
     private final String name;
     private final String extension;
@@ -81,5 +82,26 @@ public class PublishArtifactInfo {
 
     public File getFile() {
         return file;
+    }
+    
+    public int compareTo(PublishArtifactInfo other) {
+        return file.compareTo(other.getFile());
+    }
+    
+     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PublishArtifactInfo info = (PublishArtifactInfo) o;
+        return file.equals(info.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return file.hashCode();
     }
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
@@ -357,7 +357,8 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
             password = "";
         }
 
-        Set<GradleDeployDetails> allDeployDetails = Sets.newHashSet();
+        //Sort all the deploy artifacts by the natural ordering of GradleDeployDetails
+        Set<GradleDeployDetails> allDeployDetails = Sets.newTreeSet();
 
         // Update the artifacts for all project build info task
         List<BuildInfoBaseTask> orderedTasks = getAllBuildInfoTasks();
@@ -385,8 +386,7 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
                         acc.publisher.getExcludePatterns());
                 configureProxy(acc, client);
                 configConnectionTimeout(acc, client);
-                Map<String, Set<GradleDeployDetails>> deployDetailsPerProject = arrangeDeployDetailsByProject(allDeployDetails);
-                deployArtifacts(deployDetailsPerProject, client, patterns);
+                deployArtifacts(allDeployDetails, client, patterns);
             }
 
             //Extract build info and update the clientConf info accordingly (build name, num, etc.)
@@ -412,42 +412,18 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
         }
     }
 
-    /**
-     * Group artifacts by the project name
-     *
-     * @param gradleDeployDetailsSet flatten set of all artifacts deploy details
-     * @return map with project names as keys and group of all project related artifacts details
-     */
-    private Map<String, Set<GradleDeployDetails>> arrangeDeployDetailsByProject(Set<GradleDeployDetails> gradleDeployDetailsSet) {
-        Map<String, Set<GradleDeployDetails>> arrangedDeployDetails = Maps.newHashMap();
-        for (GradleDeployDetails gradleDeployDetails : gradleDeployDetailsSet) {
-            String projectName = gradleDeployDetails.getProject().getName();
-            if (arrangedDeployDetails.containsKey(projectName)) {
-                arrangedDeployDetails.get(projectName).add(gradleDeployDetails);
-            } else {
-                Set<GradleDeployDetails> gradleDeployDetailsForProject = Sets.newHashSet(gradleDeployDetails);
-                arrangedDeployDetails.put(projectName, gradleDeployDetailsForProject);
-            }
-        }
-        return arrangedDeployDetails;
-    }
-
-
-    private void deployArtifacts(Map<String, Set<GradleDeployDetails>> deployDetailsPerProject, ArtifactoryBuildInfoClient client,
+    private void deployArtifacts(Set<GradleDeployDetails> allDeployDetails, ArtifactoryBuildInfoClient client,
                                  IncludeExcludePatterns patterns)
             throws IOException {
-        for (String projectName : deployDetailsPerProject.keySet()) {
-            Set<GradleDeployDetails> deployDetailsForProject = deployDetailsPerProject.get(projectName);
-            for (GradleDeployDetails detail : deployDetailsForProject) {
-                DeployDetails deployDetails = detail.getDeployDetails();
-                String artifactPath = deployDetails.getArtifactPath();
-                if (PatternMatcher.pathConflicts(artifactPath, patterns)) {
-                    log.log(LogLevel.LIFECYCLE, "Skipping the deployment of '" + artifactPath +
-                            "' due to the defined include-exclude patterns.");
-                    continue;
-                }
-                client.deployArtifact(deployDetails);
+        for (GradleDeployDetails detail : allDeployDetails) {
+            DeployDetails deployDetails = detail.getDeployDetails();
+            String artifactPath = deployDetails.getArtifactPath();
+            if (PatternMatcher.pathConflicts(artifactPath, patterns)) {
+                log.log(LogLevel.LIFECYCLE, "Skipping the deployment of '" + artifactPath +
+                        "' due to the defined include-exclude patterns.");
+                continue;
             }
+            client.deployArtifact(deployDetails);
         }
     }
 

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/context/BuildContext.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/context/BuildContext.java
@@ -6,9 +6,10 @@ import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfigurat
 import org.jfrog.build.client.DeployDetails;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 
 /**
@@ -27,7 +28,12 @@ public class BuildContext {
 
     public BuildContext(ArtifactoryClientConfiguration clientConf) {
         this.clientConf = clientConf;
-        deployDetails = new HashSet<DeployDetails>();
+        //Sort the deploy details by file name to ensure consistent publish order
+        deployDetails = new TreeSet(new Comparator<DeployDetails>() {
+            public int compare(DeployDetails details, DeployDetails otherDetails) {
+                return details.getFile().compareTo(otherDetails.getFile());
+            }
+        });
         modules = new ArrayList<Module>();
         dependencies = new ArrayList<Dependency>();
         buildStartTime = System.currentTimeMillis();


### PR DESCRIPTION
Currently the build extractors for Ivy and Gradle store the resulting list of artifacts to publish in a HashSet. This causes the artifacts to be published in a random order. This updates that to use a TreeSet and provides comparable implementations for related objects so that the published artifacts occur in a deterministic order. This is really helpful for us to determine when a build is complete. This would solve https://www.jfrog.com/jira/browse/GAP-181 in a more predictable manner than is currently implemented.