### PR TITLE
[HAP-909] NPE on gather build info

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -446,8 +446,10 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         for (Artifact artifact : projectDependencies) {
             String classifier = artifact.getClassifier();
             classifier = classifier == null ? "" : classifier;
+            String scope = artifact.getScope();
+            scope = StringUtils.isBlank(scope) ? Artifact.SCOPE_COMPILE : scope;  // HAP-909
             DefaultArtifact art = new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
-                    artifact.getScope(), artifact.getType(), classifier, artifact.getArtifactHandler());
+                    scope, artifact.getType(), classifier, artifact.getArtifactHandler());
 
             art.setFile(artifact.getFile());
             dependecies.add(art);


### PR DESCRIPTION
Define the default scope for the artifact dependency in case it's value is null or an empty string.
I've already accept the JFrog CLA (adobe sign)

initial discussion on issue #52 
jira issue [here](https://www.jfrog.com/jira/browse/HAP-909)