### PR TITLE
Move deploying action to a separated task

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.groovy
@@ -4,8 +4,10 @@ import org.gradle.api.Project
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 import org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask
+import org.jfrog.gradle.plugin.artifactory.task.DeployTask
 
 import static org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask.BUILD_INFO_TASK_NAME
+import static org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask.DEPLOY_TASK_NAME
 
 /**
  * @author Lior Hasson  
@@ -19,8 +21,15 @@ class ArtifactoryPlugin extends ArtifactoryPluginBase {
     @Override
     protected BuildInfoBaseTask createArtifactoryPublishTask(Project project) {
         def result = project.getTasks().create(BUILD_INFO_TASK_NAME, ArtifactoryTask.class)
-        result.setDescription('''Deploys artifacts + generated build-info metadata to Artifactory,
+        result.setDescription('''Add artifacts + generated build-info metadata to be deployed to Artifactory,
                                  using project configurations.''')
+        return result
+    }
+
+    @Override
+    protected DeployTask createArtifactoryDeployTask(Project project) {
+        def result = project.getTasks().create(DEPLOY_TASK_NAME, DeployTask.class)
+        result.setDescription('''Deploys all queued ArtifactoryTask''')
         return result
     }
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
@@ -9,38 +9,25 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.ConfigureUtil;
-import org.jfrog.build.api.Build;
-import org.jfrog.build.api.BuildInfoConfigProperties;
-import org.jfrog.build.client.DeployDetails;
-import org.jfrog.build.extractor.BuildInfoExtractorUtils;
-import org.jfrog.build.util.DeployableArtifactsUtils;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactSpecs;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
-import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
-import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
-import org.jfrog.build.extractor.retention.Utils;
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPluginUtil;
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention;
 import org.jfrog.gradle.plugin.artifactory.dsl.PropertiesConfig;
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig;
-import org.jfrog.gradle.plugin.artifactory.extractor.GradleArtifactoryClientConfigUpdater;
-import org.jfrog.gradle.plugin.artifactory.extractor.GradleBuildInfoExtractor;
-import org.jfrog.gradle.plugin.artifactory.extractor.GradleClientLogger;
 import org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Date: 3/20/13 Time: 10:32 AM
@@ -48,6 +35,7 @@ import java.util.*;
  * @author freds
  */
 public abstract class BuildInfoBaseTask extends DefaultTask {
+    public static final String DEPLOY_TASK_NAME = "artifactoryDeploy";
     public static final String BUILD_INFO_TASK_NAME = "artifactoryPublish";
     public static final String PUBLISH_ARTIFACTS = "publishArtifacts";
     public static final String PUBLISH_BUILD_INFO = "publishBuildInfo";
@@ -57,11 +45,8 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
     private static final Logger log = Logging.getLogger(BuildInfoBaseTask.class);
     private final Map<String, Boolean> flags = Maps.newHashMap();
     private boolean evaluated = false;
-    private boolean finished = false;
-	private boolean started = false;
-    public final Set<GradleDeployDetails> deployDetails = Sets.newTreeSet();
 
-    private List<BuildInfoBaseTask> artifactoryTasks = null;
+    public final Set<GradleDeployDetails> deployDetails = Sets.newTreeSet();
 
     public abstract void checkDependsOnArtifactsToPublish();
 
@@ -110,101 +95,7 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
         return getFlag(PUBLISH_POM);
     }
 
-    @TaskAction
-    public void taskAction() throws IOException {
-        try {
-            log.debug("Task '{}' activated", getPath());
-			started = true;
-            collectProjectBuildInfo();
-        } finally {
-            synchronized (this) {
-                finished = true;
-                notify();
-            }
-        }
-    }
 
-    private void collectProjectBuildInfo() throws IOException {
-        if (isLastTask()) {
-            log.debug("Starting build info extraction for project '{}' using last task in graph '{}'",
-                    new Object[]{getProject().getPath(), getPath()});
-            prepareAndDeploy();
-            String propertyFilePath = System.getenv(BuildInfoConfigProperties.PROP_PROPS_FILE);
-            if (StringUtils.isBlank(propertyFilePath)) {
-                propertyFilePath = System.getenv(BuildInfoConfigProperties.ENV_BUILDINFO_PROPFILE);
-            }
-            if (StringUtils.isNotBlank(propertyFilePath)) {
-                File file = new File(propertyFilePath);
-                if (file.exists()) {
-                    file.delete();
-                }
-            }
-        }
-    }
-
-    /**
-     * Indicates whether this ArtifactoryTask is the last task to be executed.
-     *
-     * @return true if this is the last ArtifactoryTask task.
-     */
-    private boolean isLastTask() throws IOException {
-        boolean last = getCurrentTaskIndex() == (getAllArtifactoryTasks().size() - 1);
-        if (!last) {
-            return false;
-        }
-
-        // This task has the last index in the tasks graph, but it is not necessarily
-        // the last running tasks (in case this gradle build is running in parallel mode).
-        // We should make sure there are no other running tasks.
-        // In case there are, we'll wait for them to finish:
-        for (BuildInfoBaseTask t : getAllArtifactoryTasks()) {
-            if (t == this || t.isFinished()) {
-                continue;
-            }
-            synchronized (t) {
-                if (!t.isFinished() && t.isStarted()) {
-                    try {
-                        t.wait();
-                    } catch (InterruptedException e) {
-                        throw new IOException(e);
-                    }
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Return the index of this ArtifactoryTask in the list of all tasks of type BuildInfoBaseTask.
-     *
-     * @return The task index.
-     */
-    private int getCurrentTaskIndex() {
-        List<BuildInfoBaseTask> tasks = getAllArtifactoryTasks();
-        int currentTaskIndex = tasks.indexOf(this);
-        if (currentTaskIndex == -1) {
-            throw new IllegalStateException(String.format("Could not find the current task %s in the task graph", getPath()));
-        }
-        return currentTaskIndex;
-    }
-
-    /**
-     * Analyze the task graph ordered and extract a list of build info tasks
-     *
-     * @return An ordered list of build info tasks
-     */
-    private List<BuildInfoBaseTask> getAllArtifactoryTasks() {
-        if (artifactoryTasks == null) {
-            List<BuildInfoBaseTask> tasks = new ArrayList<BuildInfoBaseTask>();
-            for (Task task : getProject().getGradle().getTaskGraph().getAllTasks()) {
-                if (task instanceof BuildInfoBaseTask) {
-                    tasks.add(((BuildInfoBaseTask) task));
-                }
-            }
-            artifactoryTasks = tasks;
-        }
-        return artifactoryTasks;
-    }
 
     public void projectsEvaluated() {
         Project project = getProject();
@@ -227,6 +118,9 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
             }
 
             // Depend on buildInfo task in sub-projects
+            Task deployTask = project.getRootProject().getTasks().findByName(DEPLOY_TASK_NAME);
+            finalizedBy(deployTask);
+
             for (Project sub : project.getSubprojects()) {
                 Task subBiTask = sub.getTasks().findByName(BUILD_INFO_TASK_NAME);
                 if (subBiTask != null) {
@@ -247,14 +141,6 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
         return skip;
     }
 
-    public boolean isFinished() {
-        return finished;
-    }
-
-	public boolean isStarted() {
-		return started;
-	}
-	
     public void setProperties(Map<String, CharSequence> props) {
         if (props == null || props.isEmpty()) {
             return;
@@ -318,85 +204,6 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
         setFlag(PUBLISH_ARTIFACTS, toBoolean(publishArtifacts));
     }
 
-    private void configureProxy(ArtifactoryClientConfiguration clientConf, ArtifactoryBuildInfoClient client) {
-        ArtifactoryClientConfiguration.ProxyHandler proxy = clientConf.proxy;
-        String proxyHost = proxy.getHost();
-        if (StringUtils.isNotBlank(proxyHost) && proxy.getPort() != null) {
-            log.debug("Found proxy host '{}'", proxyHost);
-            String proxyUserName = proxy.getUsername();
-            if (StringUtils.isNotBlank(proxyUserName)) {
-                log.debug("Found proxy user name '{}'", proxyUserName);
-                client.setProxyConfiguration(proxyHost, proxy.getPort(), proxyUserName, proxy.getPassword());
-            } else {
-                log.debug("No proxy user name and password found, using anonymous proxy");
-                client.setProxyConfiguration(proxyHost, proxy.getPort());
-            }
-        }
-    }
-
-    protected void configConnectionTimeout(ArtifactoryClientConfiguration clientConf, ArtifactoryBuildInfoClient client) {
-        if (clientConf.getTimeout() != null) {
-            client.setConnectionTimeout(clientConf.getTimeout());
-        }
-    }
-
-    protected void configRetriesParams(ArtifactoryClientConfiguration clientConf, ArtifactoryBuildInfoClient client) {
-        if (clientConf.getConnectionRetries() != null) {
-            client.setConnectionRetries(clientConf.getConnectionRetries());
-        }
-    }
-
-    private File getExportFile(ArtifactoryClientConfiguration clientConf) {
-        String fileExportPath = clientConf.getExportFile();
-        if (StringUtils.isNotBlank(fileExportPath)) {
-            return new File(fileExportPath);
-        }
-        Project rootProject = getProject().getRootProject();
-        return new File(rootProject.getBuildDir(), "build-info.json");
-    }
-
-    private void exportBuildInfo(Build build, File toFile) throws IOException {
-        log.debug("Exporting generated build info to '{}'", toFile.getAbsolutePath());
-        BuildInfoExtractorUtils.saveBuildInfoToFile(build, toFile);
-    }
-
-    private void exportDeployableArtifacts(Set<GradleDeployDetails> allDeployDetails, File toFile) throws IOException {
-        log.debug("Exporting deployable artifacts to '{}'", toFile.getAbsolutePath());
-        Set<DeployDetails> deploySet = Sets.newLinkedHashSet();
-        for (GradleDeployDetails details : allDeployDetails) {
-            deploySet.add(details.getDeployDetails());
-        }
-        DeployableArtifactsUtils.saveDeployableArtifactsToFile(deploySet, toFile);
-    }
-
-    @Nonnull
-    private Boolean isPublishArtifacts(ArtifactoryClientConfiguration acc) {
-        Boolean publishArtifacts = getPublishArtifacts();
-        if (publishArtifacts == null) {
-            return acc.publisher.isPublishArtifacts();
-        }
-        return publishArtifacts;
-    }
-
-    @Nonnull
-    private Boolean isPublishBuildInfo(ArtifactoryClientConfiguration acc) {
-        Boolean publishBuildInfo = getPublishBuildInfo();
-        if (publishBuildInfo == null) {
-            return acc.publisher.isPublishBuildInfo();
-        }
-        return publishBuildInfo;
-    }
-
-    @Nonnull
-    private Boolean isGenerateBuildInfoToFile(ArtifactoryClientConfiguration acc) {
-        return !StringUtils.isEmpty(acc.info.getGeneratedBuildInfoFilePath());
-    }
-
-    @Nonnull
-    private Boolean isGenerateDeployableArtifactsToFile(ArtifactoryClientConfiguration acc) {
-        return !StringUtils.isEmpty(acc.info.getDeployableArtifactsFilePath());
-    }
-
     @Nullable
     private Boolean getFlag(String flagName) {
         return flags.get(flagName);
@@ -404,141 +211,6 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
 
     private Boolean toBoolean(Object o) {
         return Boolean.valueOf(o.toString());
-    }
-
-    /**
-     * This method will be activated only at the "end" of the build, when we reached the root project.
-     *
-     * @throws java.io.IOException In case the deployment fails.
-     */
-    private void prepareAndDeploy() throws IOException {
-        ArtifactoryClientConfiguration accRoot =
-                ArtifactoryPluginUtil.getArtifactoryConvention(getProject()).getClientConfig();
-
-        Map<String, String> propsRoot = accRoot.publisher.getProps();
-
-        // Reset the default properties, they may have changed
-        GradleArtifactoryClientConfigUpdater.setMissingBuildAttributes(
-                accRoot, getProject().getRootProject());
-
-        Set<GradleDeployDetails> allDeployDetails = Sets.newTreeSet();
-        List<BuildInfoBaseTask> orderedTasks = getAllArtifactoryTasks();
-        for (BuildInfoBaseTask bit : orderedTasks) {
-            if (bit.getDidWork()) {
-                ArtifactoryClientConfiguration.PublisherHandler publisher =
-                        ArtifactoryPluginUtil.getPublisherHandler(bit.getProject());
-
-                if (publisher != null && publisher.getContextUrl() != null) {
-                    Map<String, String> moduleProps = new HashMap<String, String>(propsRoot);
-                    moduleProps.putAll(publisher.getProps());
-                    publisher.getProps().putAll(moduleProps);
-                    String contextUrl = publisher.getContextUrl();
-                    String username = publisher.getUsername();
-                    String password = publisher.getPassword();
-                    if (StringUtils.isBlank(username)) {
-                        username = "";
-                    }
-                    if (StringUtils.isBlank(password)) {
-                        password = "";
-                    }
-
-                    bit.collectDescriptorsAndArtifactsForUpload();
-                    if (publisher.isPublishArtifacts()) {
-                        ArtifactoryBuildInfoClient client = null;
-                        try {
-                            client = new ArtifactoryBuildInfoClient(contextUrl, username, password,
-                                    new GradleClientLogger(log));
-
-                            log.debug("Uploading artifacts to Artifactory at '{}'", contextUrl);
-                            IncludeExcludePatterns patterns = new IncludeExcludePatterns(
-                                    publisher.getIncludePatterns(),
-                                    publisher.getExcludePatterns());
-                            configureProxy(accRoot, client);
-                            configConnectionTimeout(accRoot, client);
-                            configRetriesParams(accRoot, client);
-                            deployArtifacts(bit.deployDetails, client, patterns);
-                        } finally {
-                            if (client != null) {
-                                client.close();
-                            }
-                        }
-                    }
-                    allDeployDetails.addAll(bit.deployDetails);
-                }
-            }
-        }
-
-        ArtifactoryBuildInfoClient client = null;
-        String contextUrl = accRoot.publisher.getContextUrl();
-        String username = accRoot.publisher.getUsername();
-        String password = accRoot.publisher.getPassword();
-        if (contextUrl != null) {
-            if (StringUtils.isBlank(username)) {
-                username = "";
-            }
-            if (StringUtils.isBlank(password)) {
-                password = "";
-            }
-            try {
-                client = new ArtifactoryBuildInfoClient(
-                        accRoot.publisher.getContextUrl(),
-                        accRoot.publisher.getUsername(),
-                        accRoot.publisher.getPassword(),
-                        new GradleClientLogger(log));
-                configureProxy(accRoot, client);
-                configConnectionTimeout(accRoot, client);
-                configRetriesParams(accRoot, client);
-                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot, allDeployDetails);
-                Build build = gbie.extract(getProject().getRootProject());
-                exportBuildInfo(build, getExportFile(accRoot));
-                if (isPublishBuildInfo(accRoot)) {
-                    // If export property set always save the file before sending it to artifactory
-                    exportBuildInfo(build, getExportFile(accRoot));
-                    if (accRoot.info.isIncremental()) {
-                        log.debug("Publishing build info modules to artifactory at: '{}'", contextUrl);
-                        client.sendModuleInfo(build);
-                    } else {
-                        log.debug("Publishing build info to artifactory at: '{}'", contextUrl);
-                        Utils.sendBuildAndBuildRetention(client, build, accRoot);
-                    }
-                }
-                if (isGenerateBuildInfoToFile(accRoot)) {
-                    try {
-                        exportBuildInfo(build, new File(accRoot.info.getGeneratedBuildInfoFilePath()));
-                    } catch (Exception e) {
-                        log.error("Failed writing build info to file: ", e);
-                        throw new IOException("Failed writing build info to file", e);
-                    }
-                }
-                if (isGenerateDeployableArtifactsToFile(accRoot)) {
-                    try {
-                        exportDeployableArtifacts(allDeployDetails, new File(accRoot.info.getDeployableArtifactsFilePath()));
-                    } catch (Exception e) {
-                        log.error("Failed writing deployable artifacts to file: ", e);
-                        throw new RuntimeException("Failed writing deployable artifacts to file", e);
-                    }
-                }
-            } finally {
-                if (client != null) {
-                    client.close();
-                }
-            }
-        }
-    }
-
-    private void deployArtifacts(Set<GradleDeployDetails> allDeployDetails, ArtifactoryBuildInfoClient client,
-                                 IncludeExcludePatterns patterns)
-            throws IOException {
-        for (GradleDeployDetails detail : allDeployDetails) {
-            DeployDetails deployDetails = detail.getDeployDetails();
-            String artifactPath = deployDetails.getArtifactPath();
-            if (PatternMatcher.pathConflicts(artifactPath, patterns)) {
-                log.log(LogLevel.LIFECYCLE, "Skipping the deployment of '" + artifactPath +
-                        "' due to the defined include-exclude patterns.");
-                continue;
-            }
-            client.deployArtifact(deployDetails);
-        }
     }
 
     private void setFlag(String flagName, Boolean newValue) {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
@@ -38,7 +38,6 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
     public static final String DEPLOY_TASK_NAME = "artifactoryDeploy";
     public static final String BUILD_INFO_TASK_NAME = "artifactoryPublish";
     public static final String PUBLISH_ARTIFACTS = "publishArtifacts";
-    public static final String PUBLISH_BUILD_INFO = "publishBuildInfo";
     public static final String PUBLISH_IVY = "publishIvy";
     public static final String PUBLISH_POM = "publishPom";
 
@@ -66,13 +65,6 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
 
     @Input
     public boolean skip = false;
-
-    @Input
-    @Optional
-    @Nullable
-    public Boolean getPublishBuildInfo() {
-        return getFlag(PUBLISH_BUILD_INFO);
-    }
 
     @Input
     @Optional
@@ -192,11 +184,6 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
 
     public void setPublishPom(Object publishPom) {
         setFlag(PUBLISH_POM, toBoolean(publishPom));
-    }
-
-    //Publish build-info to Artifactory (true by default)
-    public void setPublishBuildInfo(Object publishBuildInfo) {
-        setFlag(PUBLISH_BUILD_INFO, toBoolean(publishBuildInfo));
     }
 
     //Publish artifacts to Artifactory (true by default)

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/BuildInfoBaseTask.java
@@ -58,6 +58,7 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
     private final Map<String, Boolean> flags = Maps.newHashMap();
     private boolean evaluated = false;
     private boolean finished = false;
+	private boolean started = false;
     public final Set<GradleDeployDetails> deployDetails = Sets.newTreeSet();
 
     private List<BuildInfoBaseTask> artifactoryTasks = null;
@@ -113,6 +114,7 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
     public void taskAction() throws IOException {
         try {
             log.debug("Task '{}' activated", getPath());
+			started = true;
             collectProjectBuildInfo();
         } finally {
             synchronized (this) {
@@ -160,7 +162,7 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
                 continue;
             }
             synchronized (t) {
-                if (!t.isFinished()) {
+                if (!t.isFinished() && t.isStarted()) {
                     try {
                         t.wait();
                     } catch (InterruptedException e) {
@@ -249,6 +251,10 @@ public abstract class BuildInfoBaseTask extends DefaultTask {
         return finished;
     }
 
+	public boolean isStarted() {
+		return started;
+	}
+	
     public void setProperties(Map<String, CharSequence> props) {
         if (props == null || props.isEmpty()) {
             return;

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -1,0 +1,274 @@
+package org.jfrog.gradle.plugin.artifactory.task;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.execution.TaskExecutionGraph;
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+import org.jfrog.build.api.Build;
+import org.jfrog.build.api.BuildInfoConfigProperties;
+import org.jfrog.build.client.DeployDetails;
+import org.jfrog.build.extractor.BuildInfoExtractorUtils;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
+import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
+import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
+import org.jfrog.build.extractor.retention.Utils;
+import org.jfrog.build.util.DeployableArtifactsUtils;
+import org.jfrog.gradle.plugin.artifactory.ArtifactoryPluginUtil;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleArtifactoryClientConfigUpdater;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleBuildInfoExtractor;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleClientLogger;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleDeployDetails;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * @author Ruben Perez
+ */
+public class DeployTask extends DefaultTask {
+
+    private static final Logger log = Logging.getLogger(DeployTask.class);
+
+    @TaskAction
+    public void taskAction() throws IOException {
+        log.debug("Task '{}' activated", getPath());
+        collectProjectBuildInfo();
+    }
+
+    private void collectProjectBuildInfo() throws IOException {
+        log.debug("Starting build info extraction for project '{}' using last task in graph '{}'",
+                new Object[]{getProject().getPath(), getPath()});
+        prepareAndDeploy();
+        String propertyFilePath = System.getenv(BuildInfoConfigProperties.PROP_PROPS_FILE);
+        if (StringUtils.isBlank(propertyFilePath)) {
+            propertyFilePath = System.getenv(BuildInfoConfigProperties.ENV_BUILDINFO_PROPFILE);
+        }
+        if (StringUtils.isNotBlank(propertyFilePath)) {
+            File file = new File(propertyFilePath);
+            if (file.exists()) {
+                file.delete();
+            }
+        }
+    }
+
+    /**
+     * This method will be activated only at the "end" of the build, when we reached the root project.
+     *
+     * @throws java.io.IOException In case the deployment fails.
+     */
+    private void prepareAndDeploy() throws IOException {
+        ArtifactoryClientConfiguration accRoot =
+                ArtifactoryPluginUtil.getArtifactoryConvention(getProject()).getClientConfig();
+
+        Map<String, String> propsRoot = accRoot.publisher.getProps();
+
+        // Reset the default properties, they may have changed
+        GradleArtifactoryClientConfigUpdater.setMissingBuildAttributes(
+                accRoot, getProject().getRootProject());
+
+        Set<GradleDeployDetails> allDeployDetails = Sets.newTreeSet();
+        List<BuildInfoBaseTask> orderedTasks = findBuildInfoBaseTasks(getProject().getGradle().getTaskGraph());
+        for (BuildInfoBaseTask bit : orderedTasks) {
+            if (bit.getDidWork()) {
+                ArtifactoryClientConfiguration.PublisherHandler publisher =
+                        ArtifactoryPluginUtil.getPublisherHandler(bit.getProject());
+
+                if (publisher != null && publisher.getContextUrl() != null) {
+                    Map<String, String> moduleProps = new HashMap<String, String>(propsRoot);
+                    moduleProps.putAll(publisher.getProps());
+                    publisher.getProps().putAll(moduleProps);
+                    String contextUrl = publisher.getContextUrl();
+                    String username = publisher.getUsername();
+                    String password = publisher.getPassword();
+                    if (StringUtils.isBlank(username)) {
+                        username = "";
+                    }
+                    if (StringUtils.isBlank(password)) {
+                        password = "";
+                    }
+
+                    bit.collectDescriptorsAndArtifactsForUpload();
+                    if (publisher.isPublishArtifacts()) {
+                        ArtifactoryBuildInfoClient client = null;
+                        try {
+                            client = new ArtifactoryBuildInfoClient(contextUrl, username, password,
+                                    new GradleClientLogger(log));
+
+                            log.debug("Uploading artifacts to Artifactory at '{}'", contextUrl);
+                            IncludeExcludePatterns patterns = new IncludeExcludePatterns(
+                                    publisher.getIncludePatterns(),
+                                    publisher.getExcludePatterns());
+                            configureProxy(accRoot, client);
+                            configConnectionTimeout(accRoot, client);
+                            configRetriesParams(accRoot, client);
+                            deployArtifacts(bit.deployDetails, client, patterns);
+                        } finally {
+                            if (client != null) {
+                                client.close();
+                            }
+                        }
+                    }
+                    allDeployDetails.addAll(bit.deployDetails);
+                }
+            }
+        }
+
+        ArtifactoryBuildInfoClient client = null;
+        String contextUrl = accRoot.publisher.getContextUrl();
+        String username = accRoot.publisher.getUsername();
+        String password = accRoot.publisher.getPassword();
+        if (contextUrl != null) {
+            if (StringUtils.isBlank(username)) {
+                username = "";
+            }
+            if (StringUtils.isBlank(password)) {
+                password = "";
+            }
+            try {
+                client = new ArtifactoryBuildInfoClient(
+                        accRoot.publisher.getContextUrl(),
+                        accRoot.publisher.getUsername(),
+                        accRoot.publisher.getPassword(),
+                        new GradleClientLogger(log));
+                configureProxy(accRoot, client);
+                configConnectionTimeout(accRoot, client);
+                configRetriesParams(accRoot, client);
+                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot, allDeployDetails);
+                Build build = gbie.extract(getProject().getRootProject());
+                exportBuildInfo(build, getExportFile(accRoot));
+                if (isPublishBuildInfo(accRoot)) {
+                    // If export property set always save the file before sending it to artifactory
+                    exportBuildInfo(build, getExportFile(accRoot));
+                    if (accRoot.info.isIncremental()) {
+                        log.debug("Publishing build info modules to artifactory at: '{}'", contextUrl);
+                        client.sendModuleInfo(build);
+                    } else {
+                        log.debug("Publishing build info to artifactory at: '{}'", contextUrl);
+                        Utils.sendBuildAndBuildRetention(client, build, accRoot);
+                    }
+                }
+                if (isGenerateBuildInfoToFile(accRoot)) {
+                    try {
+                        exportBuildInfo(build, new File(accRoot.info.getGeneratedBuildInfoFilePath()));
+                    } catch (Exception e) {
+                        log.error("Failed writing build info to file: ", e);
+                        throw new IOException("Failed writing build info to file", e);
+                    }
+                }
+                if (isGenerateDeployableArtifactsToFile(accRoot)) {
+                    try {
+                        exportDeployableArtifacts(allDeployDetails, new File(accRoot.info.getDeployableArtifactsFilePath()));
+                    } catch (Exception e) {
+                        log.error("Failed writing deployable artifacts to file: ", e);
+                        throw new RuntimeException("Failed writing deployable artifacts to file", e);
+                    }
+                }
+            } finally {
+                if (client != null) {
+                    client.close();
+                }
+            }
+        }
+    }
+
+    private void configureProxy(ArtifactoryClientConfiguration clientConf, ArtifactoryBuildInfoClient client) {
+        ArtifactoryClientConfiguration.ProxyHandler proxy = clientConf.proxy;
+        String proxyHost = proxy.getHost();
+        if (StringUtils.isNotBlank(proxyHost) && proxy.getPort() != null) {
+            log.debug("Found proxy host '{}'", proxyHost);
+            String proxyUserName = proxy.getUsername();
+            if (StringUtils.isNotBlank(proxyUserName)) {
+                log.debug("Found proxy user name '{}'", proxyUserName);
+                client.setProxyConfiguration(proxyHost, proxy.getPort(), proxyUserName, proxy.getPassword());
+            } else {
+                log.debug("No proxy user name and password found, using anonymous proxy");
+                client.setProxyConfiguration(proxyHost, proxy.getPort());
+            }
+        }
+    }
+
+    private void configConnectionTimeout(ArtifactoryClientConfiguration clientConf, ArtifactoryBuildInfoClient client) {
+        if (clientConf.getTimeout() != null) {
+            client.setConnectionTimeout(clientConf.getTimeout());
+        }
+    }
+
+    private void configRetriesParams(ArtifactoryClientConfiguration clientConf, ArtifactoryBuildInfoClient client) {
+        if (clientConf.getConnectionRetries() != null) {
+            client.setConnectionRetries(clientConf.getConnectionRetries());
+        }
+    }
+
+    private void exportBuildInfo(Build build, File toFile) throws IOException {
+        log.debug("Exporting generated build info to '{}'", toFile.getAbsolutePath());
+        BuildInfoExtractorUtils.saveBuildInfoToFile(build, toFile);
+    }
+
+    private void exportDeployableArtifacts(Set<GradleDeployDetails> allDeployDetails, File toFile) throws IOException {
+        log.debug("Exporting deployable artifacts to '{}'", toFile.getAbsolutePath());
+        Set<DeployDetails> deploySet = Sets.newLinkedHashSet();
+        for (GradleDeployDetails details : allDeployDetails) {
+            deploySet.add(details.getDeployDetails());
+        }
+        DeployableArtifactsUtils.saveDeployableArtifactsToFile(deploySet, toFile);
+    }
+
+    private File getExportFile(ArtifactoryClientConfiguration clientConf) {
+        String fileExportPath = clientConf.getExportFile();
+        if (StringUtils.isNotBlank(fileExportPath)) {
+            return new File(fileExportPath);
+        }
+        Project rootProject = getProject().getRootProject();
+        return new File(rootProject.getBuildDir(), "build-info.json");
+    }
+
+    @Nonnull
+    private Boolean isPublishBuildInfo(ArtifactoryClientConfiguration acc) {
+        return acc.publisher.isPublishBuildInfo();
+    }
+
+    @Nonnull
+    private Boolean isGenerateBuildInfoToFile(ArtifactoryClientConfiguration acc) {
+        return !StringUtils.isEmpty(acc.info.getGeneratedBuildInfoFilePath());
+    }
+
+    @Nonnull
+    private Boolean isGenerateDeployableArtifactsToFile(ArtifactoryClientConfiguration acc) {
+        return !StringUtils.isEmpty(acc.info.getDeployableArtifactsFilePath());
+    }
+
+    private void deployArtifacts(Set<GradleDeployDetails> allDeployDetails, ArtifactoryBuildInfoClient client,
+                                 IncludeExcludePatterns patterns)
+            throws IOException {
+        for (GradleDeployDetails detail : allDeployDetails) {
+            DeployDetails deployDetails = detail.getDeployDetails();
+            String artifactPath = deployDetails.getArtifactPath();
+            if (PatternMatcher.pathConflicts(artifactPath, patterns)) {
+                log.log(LogLevel.LIFECYCLE, "Skipping the deployment of '" + artifactPath +
+                        "' due to the defined include-exclude patterns.");
+                continue;
+            }
+            client.deployArtifact(deployDetails);
+        }
+    }
+
+    private List<BuildInfoBaseTask> findBuildInfoBaseTasks(TaskExecutionGraph graph) {
+        List<BuildInfoBaseTask> tasks = new ArrayList<BuildInfoBaseTask>();
+        for (Task task : graph.getAllTasks()) {
+            if (task instanceof BuildInfoBaseTask) {
+                tasks.add(((BuildInfoBaseTask) task));
+            }
+        }
+        return tasks;
+    }
+
+}


### PR DESCRIPTION
This was raised because of: https://github.com/JFrogDev/build-info/pull/126

The idea of deploying on the last task of the graph gets a bit complex when parallel build is enabled, as we have to deal with waiting for previous tasks to finish, parent dependencies being skipped, triggering errors.

All these complications gradle can already deal with it if you move the deploying action to a task in the rootProject, and you setup dependencies accordingly. 

By doing this I have also detected an incongruity which I needed to fix in order for this to compile:

If I got the idea right, isPublishBuildInfo() (before this diff, in BuildInfoBaseTask.java), should only check the ArtifactoryClientConfiguration, and not the artifactoryPublish task config, as otherwise, the last task specification can decide for the others (and who knows what the last task in the graph is).
