### PR TITLE
Disable doclint for Java8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,14 @@ allprojects {
     }
 }
 
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
 artifactory {
     contextUrl = 'https://localhost:8080/artifactory'
     //contextUrl = 'https://oss.jfrog.org'


### PR DESCRIPTION
The project doesn't build here for Java8, with some javadoc comments failing the build because of doclint.
For example: BuildDependencyPattern triggers a 'bad use of >' for its comment line "libs-release-local:com/goldin/plugins/gradle/0.1.1/*.jar;status+=prod@gradle-plugins :: Build :: Gradle#LATEST => many-jars-build"

Simply disable doclint for now...
See http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html