### PR TITLE
Making it work with configureOnDemand

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -43,7 +43,11 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         addArtifactoryPublishTask(project)
         if (isRootProject(project)) {
             addDeployTask(project)
+        } else {
+            //makes sure the plugin is applied in the root project
+            project.rootProject.getPluginManager().apply(ArtifactoryPlugin.class)
         }
+
         if (!conv.clientConfig.info.buildStarted) {
             conv.clientConfig.info.setBuildStarted(System.currentTimeMillis())
         }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -113,9 +113,11 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project, Bui
 
         Set<Project> allProjects = rootProject.getAllprojects();
         for (Project project : allProjects) {
-            ArtifactoryTask buildInfoTask = getBuildInfoTask(project);
-            if (buildInfoTask != null && buildInfoTask.hasModules()) {
-                bib.addModule(extractModule(project));
+            if(project.getState().getExecuted()) {
+                ArtifactoryTask buildInfoTask = getBuildInfoTask(project);
+                if (buildInfoTask != null && buildInfoTask.hasModules()) {
+                    bib.addModule(extractModule(project));
+                }
             }
         }
         String parentName = clientConf.info.getParentBuildName();

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -119,6 +119,8 @@ public class DeployTask extends DefaultTask {
                     }
                     allDeployDetails.addAll(artifactoryTask.deployDetails);
                 }
+            } else {
+                log.debug("task '{}' did no work", artifactoryTask.getPath());
             }
         }
 


### PR DESCRIPTION
The plugin does not work properly with ConfigureOnDemand.

The callback projectsEvaluated is actually not a good place to do things like "finalizedBy", because in case of using it with configure-on-demand, it gets called when the configuration is already done.

Look at the following SSCCE to reproduce the problem (which is doing the same as you do).
[testGradle.zip](https://github.com/JFrogDev/build-info/files/1635366/testGradle.zip)
