### PR TITLE
Fix ensureEnds function to use File.separator instead of default "/" …

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
@@ -452,6 +452,6 @@ public class UploadSpecHelper {
     }
 
     private static String ensureEnds(String s, char endsWith) {
-        return StringUtils.endsWith(s, "/") ? s : (new StringBuilder()).append(s).append(endsWith).toString();
+        return StringUtils.endsWith(s, String.valueOf(endsWith)) ? s : (new StringBuilder()).append(s).append(endsWith).toString();
     }
 }


### PR DESCRIPTION
…unix separator

- ensureEnds function always look for "/" (unix file separator) even on
  windows. This causes issues in Jenkins when your workspace is T:\

  If you use custom workspace and set to T:\ or some root drive then
  ensureEnds function adds additional "\" resulting in "T:\\".
  getRelativepath which uses this function then ends up adding
  ".." in remote target path. This results in 500 error from artifactory.

  Deploying artifact: https://artifactory.garmin.com/artifactory/Marine-Builds/Regression/ByJob/Mar-Man-openstack-win-TEST/19/../Artifacts/me.txt
  ERROR: remote file operation failed: T:\ at hudson.remoting.Channel@522d50a:os-cw7x-e1c: java.io.IOException: Failed to deploy file. Status code: 500 Response message: Artifactory returned the following errors:
  Path element cannot end with a dot: Marine-Builds/Regression/ByJob/Mar-Man-openstack-win-TEST/19/../ Status code: 500

- This patch addresses this issue by fixing ensureEnds to check for
  passed in separator instead of default "/"

Change-Id: Ib08c01ba235e51b2bb752f929805eee8f4fa4407